### PR TITLE
[STC-13] Added functionality for users to upload, edit, and delete Datasets as well as the DataFiles they contain

### DIFF
--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/config/PersistenceConfig.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/config/PersistenceConfig.java
@@ -45,7 +45,10 @@ public class PersistenceConfig {
     public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource(dataSource());
-        em.setPackagesToScan(new String[] { "edu.asu.diging.scriptoocloud.core.model", "edu.asu.diging.simpleusers.core.model" });
+        em.setPackagesToScan(new String[] {
+                "edu.asu.diging.scriptoocloud.core.model",
+                "edu.asu.diging.scriptoocloud.core.data",
+                "edu.asu.diging.simpleusers.core.model" });
 
         JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
         em.setJpaVendorAdapter(vendorAdapter);

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/config/SecurityContext.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/config/SecurityContext.java
@@ -1,6 +1,5 @@
 package edu.asu.diging.scriptoocloud.config;
 
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,21 +22,23 @@ public class SecurityContext extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.formLogin()
+        http
+                .formLogin()
                 .loginPage("/login").permitAll()
                 .and()
                 .logout()
                 .deleteCookies("JSESSIONID")
                 .logoutSuccessUrl("/")
-                .and().exceptionHandling().accessDeniedPage("/403")
-                // Configures url based authorization
+                .and()
+                .exceptionHandling()
+                .accessDeniedPage("/403")
                 .and()
                 .authorizeRequests()
                 // Anyone can access the urls
-                .antMatchers("/", "/resources/**",
-                        "/register").permitAll()
+                .antMatchers("/", "/resources/**", "/register").permitAll()
                 // The rest of the our application is protected.
                 .antMatchers("/users/**", "/admin/**").hasRole("ADMIN")
+                .antMatchers("/datasets/**").authenticated()
                 .anyRequest().hasRole("USER");
     }
 

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/data/DataFileRepository.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/data/DataFileRepository.java
@@ -1,0 +1,15 @@
+package edu.asu.diging.scriptoocloud.core.data;
+import edu.asu.diging.scriptoocloud.core.model.impl.DataFile;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Repository
+public interface DataFileRepository extends PagingAndSortingRepository<DataFile, Long> {
+
+    Optional<DataFile> findByName(String name);
+
+    Set<DataFile> findAllByDatasetId(Long id );
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/data/DatasetRepository.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/data/DatasetRepository.java
@@ -1,0 +1,14 @@
+package edu.asu.diging.scriptoocloud.core.data;
+import edu.asu.diging.scriptoocloud.core.model.impl.Dataset;
+import edu.asu.diging.simpleusers.core.model.IUser;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface DatasetRepository extends PagingAndSortingRepository<Dataset, Long> {
+
+    Dataset findByName(String name);
+
+    Optional<Dataset> findByNameAndUser(String username, IUser user);
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/exceptions/DataFileException.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/exceptions/DataFileException.java
@@ -1,0 +1,12 @@
+package edu.asu.diging.scriptoocloud.core.exceptions;
+
+public class DataFileException extends RuntimeException {
+
+    public DataFileException(String message) {
+        super(message);
+    }
+
+    public DataFileException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/exceptions/DatasetException.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/exceptions/DatasetException.java
@@ -1,0 +1,12 @@
+package edu.asu.diging.scriptoocloud.core.exceptions;
+
+public class DatasetException extends RuntimeException {
+
+    public DatasetException(String message) {
+        super(message);
+    }
+
+    public DatasetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/IDataFile.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/IDataFile.java
@@ -1,0 +1,21 @@
+package edu.asu.diging.scriptoocloud.core.model;
+
+public interface IDataFile {
+
+    void setId(Long id);
+
+    Long getId();
+
+    void setName(String name);
+
+    String getName();
+
+    void setType(String type);
+
+    String getType();
+
+    void setDataset(IDataset dataset);
+
+    IDataset getDataset();
+
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/IDataset.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/IDataset.java
@@ -1,0 +1,24 @@
+package edu.asu.diging.scriptoocloud.core.model;
+
+import edu.asu.diging.scriptoocloud.core.model.impl.DataFile;
+import edu.asu.diging.simpleusers.core.model.IUser;
+
+public interface IDataset {
+
+    void setId(Long id);
+
+    Long getId();
+
+    String getName();
+
+    void setName(String name);
+
+    void setUser(IUser user);
+
+    String getUsername();
+
+    void addFile(DataFile dataFile);
+
+    void removeFile(DataFile dataFile);
+
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/impl/DataFile.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/impl/DataFile.java
@@ -1,0 +1,57 @@
+package edu.asu.diging.scriptoocloud.core.model.impl;
+
+import javax.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+public class DataFile {
+    @Id
+    @GeneratedValue(strategy= GenerationType.SEQUENCE)
+    private Long id;
+    private String name;
+    private String type;
+    @ManyToOne
+    @JoinColumn(name="datasetId", nullable=false)
+    private Dataset dataset;
+    private OffsetDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Dataset getDataset() {
+        return dataset;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setDataset(Dataset dataset) {
+        this.dataset = dataset;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/impl/Dataset.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/model/impl/Dataset.java
@@ -1,0 +1,60 @@
+package edu.asu.diging.scriptoocloud.core.model.impl;
+
+import edu.asu.diging.scriptoocloud.core.model.IDataset;
+import edu.asu.diging.simpleusers.core.model.IUser;
+import edu.asu.diging.simpleusers.core.model.impl.SimpleUser;
+import javax.persistence.*;
+import java.util.Set;
+
+@Entity
+public class Dataset implements IDataset {
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.SEQUENCE)
+    private Long id;
+    private String name;
+    @ManyToOne
+    @JoinColumn(name="username", nullable=false)
+    private SimpleUser user;
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.REMOVE, mappedBy="dataset", orphanRemoval = true)
+    private Set<DataFile> files;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id){
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setUser(IUser user) {this.user = (SimpleUser)user;}
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    public Set<DataFile> getFiles() {
+        return this.files;
+    }
+
+    public void addFile(DataFile dataFile) {files.add(dataFile);}
+
+    public void removeFile(DataFile dataFile){
+        files.remove(dataFile);
+    }
+
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/IDataFileService.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/IDataFileService.java
@@ -1,0 +1,10 @@
+package edu.asu.diging.scriptoocloud.core.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface IDataFileService {
+
+    boolean createFile(MultipartFile file, Long datasetId, String username, String datasetName);
+
+    void editFile(Long id);
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/IDatasetService.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/IDatasetService.java
@@ -1,0 +1,23 @@
+package edu.asu.diging.scriptoocloud.core.service;
+
+import edu.asu.diging.scriptoocloud.core.exceptions.DatasetException;
+import edu.asu.diging.scriptoocloud.core.model.IDataset;
+import edu.asu.diging.simpleusers.core.model.IUser;
+import java.util.List;
+
+public interface IDatasetService {
+
+    boolean createDataset(String name, IUser user) throws DatasetException;
+
+    boolean editDataset(Long id, String newName, String oldName, String username) throws DatasetException;
+
+    boolean deleteDataset(Long id) throws DatasetException ;
+
+    IDataset findById(Long id);
+
+    List<IDataset> findAll();
+
+    List<IDataset> findAllByUsername(String username);
+
+    boolean deleteFileFromDataset(Long datasetId, Long fileId) throws DatasetException;
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/impl/DataFileService.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/impl/DataFileService.java
@@ -1,0 +1,152 @@
+package edu.asu.diging.scriptoocloud.core.service.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.*;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import edu.asu.diging.scriptoocloud.core.data.DataFileRepository;
+import edu.asu.diging.scriptoocloud.core.data.DatasetRepository;
+import edu.asu.diging.scriptoocloud.core.exceptions.DataFileException;
+import edu.asu.diging.scriptoocloud.core.model.impl.DataFile;
+import edu.asu.diging.scriptoocloud.core.model.impl.Dataset;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import edu.asu.diging.scriptoocloud.core.service.IDataFileService;
+
+/**
+ * The Service class associated with user-uploaded DataFiles.  The class handles storing the
+ * files on the file system and storing DataFile data in the database.
+ */
+
+@Service
+public class DataFileService implements IDataFileService {
+
+    private final Path rootLocation;
+    private final DataFileRepository dataFileRepository;
+    private final DatasetRepository datasetRepository;
+
+    @Autowired
+    public DataFileService(StorageProperties properties,
+                           DataFileRepository dataFileRepository,
+                           DatasetRepository datasetRepository) {
+        this.rootLocation = Paths.get(properties.getLocation());
+        this.dataFileRepository = dataFileRepository;
+        this.datasetRepository = datasetRepository;
+    }
+
+    /**
+     * Creates a file on the filesystem and, if successful, stores the DataFile
+     * data in the database. A Dataset has many DataFiles and a DataFile belongs to one Dataset.
+     *
+     * @param file        A MultipartFile.
+     * @param datasetId   The primary key of the Dataset.
+     * @param username    The user / owner of the Dataset.
+     * @param datasetName The name of the Dataset.
+     * @return boolean indicating success.
+     */
+    @Override
+    public boolean createFile(MultipartFile file, Long datasetId, String username, String datasetName) {
+        boolean success;
+        String fileName = file.getOriginalFilename();
+        String type = file.getContentType();
+
+        try {
+            success = createFileInDirectory(username, datasetName, file);
+        } catch (DataFileException e) {
+            throw new DataFileException("File could not be saved in the file system", e);
+        }
+
+        // Only store file in database if saving file on filesystem was successful
+        if (success) {
+            Optional<DataFile> dataFile = dataFileRepository.findByName(fileName);
+            if (dataFile.isPresent() &&
+                    dataFile.get().getDataset().getId().equals(datasetId) &&
+                    dataFile.get().getType().equals(type)) {
+                // if a file with the same name & type already exists in the dataset, update time stamp
+                Long dataFileId = dataFile.get().getId();
+                editFile(dataFileId);
+            } else {
+                Optional<Dataset> dataset = datasetRepository.findById(datasetId);
+                if (dataset.isPresent()) {
+                    DataFile newFile = new DataFile();
+                    newFile.setDataset(dataset.get());
+                    newFile.setName(fileName);
+                    newFile.setType(type);
+                    newFile.setCreatedAt(OffsetDateTime.now());
+                    dataset.get().addFile(newFile);
+                    dataFileRepository.save(newFile);
+                }
+            }
+        }
+        return success;
+    }
+
+    /**
+     * Edits DataFiles in the database (occurs when users upload files in the same dataset with the
+     * same name and type). In this case, the only database entry which needs to be updated is the
+     * createdAt field.
+     *
+     * @param id The id of the DataFile to be updated
+     */
+    @Override
+    public void editFile(Long id) {
+        Optional<DataFile> datafile = dataFileRepository.findById(id);
+        datafile.ifPresent(dataFile -> dataFile.setCreatedAt(OffsetDateTime.now()));
+    }
+
+
+    /**
+     * Stores the user-uploaded file on the file system.
+     *
+     * @param username    The name (primary key) of the user / owner of the Dataset to which
+     *                    the file belongs.
+     * @param datasetName The name of the Dataset to which the file belongs.
+     * @param file        The MultipartFile to be stored.
+     * @return boolean indicating success.
+     * @throws DataFileException If the file could not be stored on the file system.
+     */
+    private boolean createFileInDirectory(String username, String datasetName, MultipartFile file)
+            throws DataFileException {
+        InputStream inputStream = null;
+
+        if (file.isEmpty()) {
+            throw new DataFileException("Failed to store empty file.");
+        }
+        if (username == null || datasetName == null) {
+            throw new DataFileException(
+                    "Cannot create file path with null values for username or dataSet name");
+        }
+        Path destinationFile = this.rootLocation.resolve(
+                Paths.get(username, datasetName, file.getOriginalFilename()))
+                .normalize().toAbsolutePath();
+        // make sure path structure is:
+        // /serverRoot/username/datasetName/file
+        if (!destinationFile.getParent().getParent().getParent()
+                .equals(this.rootLocation.toAbsolutePath())) {
+            // This is a security check
+            throw new DataFileException("Cannot store file at calculated location");
+        }
+        try {
+            inputStream = file.getInputStream();
+            Files.copy(inputStream, destinationFile,
+                    StandardCopyOption.REPLACE_EXISTING);
+            return true;
+        } catch (IOException e) {
+            try {
+                if (inputStream != null)
+                    inputStream.close();
+            } catch (IOException ex) {
+                throw new DataFileException(
+                        "File could not be copied to its directory and InputStream could not be closed", ex);
+            }
+            throw new DataFileException(
+                    "An IO Error occurred while copying the file to its directory", e);
+        } catch (SecurityException e) {
+            throw new DataFileException(
+                    "A Security Exception occurred while copying the file to its directory", e);
+        }
+    }
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/impl/DatasetService.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/impl/DatasetService.java
@@ -1,0 +1,368 @@
+package edu.asu.diging.scriptoocloud.core.service.impl;
+
+import edu.asu.diging.scriptoocloud.core.data.DataFileRepository;
+import edu.asu.diging.scriptoocloud.core.data.DatasetRepository;
+import edu.asu.diging.scriptoocloud.core.exceptions.DatasetException;
+import edu.asu.diging.scriptoocloud.core.model.IDataset;
+import edu.asu.diging.scriptoocloud.core.model.impl.DataFile;
+import edu.asu.diging.scriptoocloud.core.model.impl.Dataset;
+import edu.asu.diging.scriptoocloud.core.service.IDatasetService;
+import edu.asu.diging.simpleusers.core.model.IUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.Optional;
+
+/**
+ * The Service class associated with user Datasets.  The class handles creating directories on
+ * on the file system and the association between Datasets and DataFiles they contain.
+ */
+
+@Service
+public class DatasetService implements IDatasetService {
+
+    private final String rootLocationString;
+    private final DatasetRepository datasetRepository;
+    private final DataFileRepository dataFileRepository;
+
+    @Autowired
+    public DatasetService(StorageProperties properties,
+                          DatasetRepository datasetRepository,
+                          DataFileRepository dataFileRepository) {
+        this.rootLocationString = properties.getLocation();
+        this.datasetRepository = datasetRepository;
+        this.dataFileRepository = dataFileRepository;
+    }
+
+    /**
+     * Creates the dataset in the filesystem, then in the database.
+     *
+     * @param name The name of the dataset.
+     * @param user The IUser who owns the dataset
+     * @throws DatasetException Exception thrown if dataset with same name already exists.
+     */
+    @Override
+    public boolean createDataset(String name, IUser user) throws DatasetException {
+
+        boolean success;
+        // create directories on the file system
+        try {
+            success = addDatasetDirectories(name, user.getUsername());
+        } catch (DatasetException e) {
+            throw new DatasetException(
+                    "An IOException prevented the Dataset from being created", e);
+        }
+
+        if (success) {
+            // create directories in the database
+            Optional<Dataset> existingDataset = datasetRepository.findByNameAndUser(name, user);
+            if (existingDataset.isPresent()) {
+                throw new DatasetException("User already has a dataset with this name");
+            }
+            Dataset dataset = new Dataset();
+            dataset.setName(name);
+            dataset.setUser(user);
+            datasetRepository.save(dataset);
+        }
+        return success;
+    }
+
+    /**
+     * Edits the dataset in the filesystem, then in the database.
+     *
+     * @param id       The id of the dataset to edit.
+     * @param newName  The new name of the dataset to edit.
+     * @param oldName  The old name of the dataset to edit.
+     * @param username The username
+     * @throws DatasetException If Dataset directories couldn't be edited.
+     */
+    @Override
+    public boolean editDataset(Long id, String newName, String oldName, String username)
+            throws DatasetException {
+        boolean success;
+        try {
+            success = editDatasetDirectories(username, oldName, newName);
+        } catch (SecurityException e){
+            throw new DatasetException("A SecurityException prevented editing the Dataset", e);
+        } catch (NullPointerException e) {
+            throw new DatasetException("A NullPointer prevented editing the Dataset", e);
+        }
+
+        Optional<Dataset> dataset = datasetRepository.findById(id);
+        if (dataset.isPresent()) {
+            dataset.get().setName(newName);
+            datasetRepository.save(dataset.get());
+        }
+        return success;
+    }
+
+    /**
+     * Deletes the dataset in the filesystem, then in the database.
+     *
+     * @param id The id of the dataset to delete.
+     * @return Boolean indicating success.
+     * @throws DatasetException If the Dataset couldn't be deleted
+     */
+    @Override
+    public boolean deleteDataset(Long id) throws DatasetException {
+        boolean success;
+        // Delete Dataset Directories and files from the filesystem
+        try {
+            success = deleteDatasetDirectories(id);
+        } catch (SecurityException e) {
+            throw new DatasetException("Read access to directory was denied", e);
+        }
+        // Then delete Dataset and its files from the database
+        Optional<Dataset> dataset = datasetRepository.findById(id);
+        if (dataset.isPresent()) {
+            Set<DataFile> files = dataset.get().getFiles();
+            for (DataFile file : files) {
+                dataFileRepository.deleteById(file.getId());
+            }
+        }
+        datasetRepository.deleteById(id);
+        return success;
+    }
+
+    /**
+     * Finds a dataset in the database given a particular id.
+     *
+     * @param id The id of the dataset.
+     * @return Returns the IDataset.
+     */
+    @Override
+    public IDataset findById(Long id) {
+        Optional<Dataset> foundDataset = datasetRepository.findById(id);
+        return foundDataset.orElse(null);
+    }
+
+    /**
+     * Finds all datasets in the database (Likely for admin use).
+     *
+     * @return Returns a List of all IDatasets corresponding to Datasets in the database.
+     */
+    @Override
+    public List<IDataset> findAll() {
+        Iterable<Dataset> datasets = datasetRepository.findAll();
+        List<IDataset> results = new ArrayList<>();
+        datasets.iterator().forEachRemaining(results::add);
+        return results;
+    }
+
+    /**
+     * Finds all Datasets in the database for a particular user
+     *
+     * @param username The username of the owner of the database.
+     * @return Returns a List of all IDatasets for a given user corresponding to Datasets in the database.
+     */
+    @Override
+    public List<IDataset> findAllByUsername(String username) {
+        Iterable<Dataset> datasets = datasetRepository.findAll();
+        List<IDataset> results = new ArrayList<>();
+        datasets.iterator().forEachRemaining(d -> {
+            if (d.getUsername().equals(username)) {
+                results.add(d);
+            }
+        });
+        return results;
+    }
+
+    /**
+     * Deletes a DataFile from a Dataset. This involves: 1. Removing the file from the appropriate
+     * location on the file system and 2. Removing the file from the database ensuring that the
+     * association with the parent Dataset is removed as well.
+     *
+     * @param datasetId The primary key of the Dataset
+     * @param fileId    The primary key of the DataFile
+     * @return boolean indicating success.
+     * @throws DatasetException Exception detailing possible errors with the file and file system.
+     */
+    @Override
+    public boolean deleteFileFromDataset(Long datasetId, Long fileId) throws DatasetException {
+        boolean success = false;
+        String username;
+        String datasetName;
+        String fileName;
+
+        Optional<Dataset> dataset = datasetRepository.findById(datasetId);
+        Optional<DataFile> dataFile = dataFileRepository.findById(fileId);
+        if (dataset.isPresent() && dataFile.isPresent()) {
+            username = dataset.get().getUsername();
+            datasetName = dataset.get().getName();
+
+            fileName = dataFile.get().getName();
+
+            // Remove join from dataset
+            dataset.get().getFiles().remove(dataFile.get());
+            datasetRepository.save(dataset.get());
+
+            // delete file from database
+            dataFileRepository.deleteById(fileId);
+
+            try {
+                // Removes file from file system
+                Path path = createPath(username, datasetName);
+                String pathString = path.toString();
+                path = Paths.get(pathString, fileName);
+                File fileToBeDeleted = path.toFile();
+                success = fileToBeDeleted.delete();
+            } catch (InvalidPathException e) {
+                throw new DatasetException("Path to file could not be found", e);
+            } catch (UnsupportedOperationException e) {
+                throw new DatasetException("Could not convert path to File", e);
+            } catch (SecurityException e) {
+                throw new DatasetException("File was created, but could not be deleted", e);
+            }
+        }
+        return success;
+    }
+
+    /**
+     * Creates the dataset (and its required directories) on the filesystem.
+     *
+     * @param name     The name of the dataset.
+     * @param username The username of the dataset.
+     * @throws DatasetException The exception thrown if the directory could not be created.
+     */
+
+    private boolean addDatasetDirectories(String name, String username) throws DatasetException {
+        boolean success = false;
+        // First, the correct directory must be created
+        Path path = createPath(username, name);
+        File directory = path.toFile();
+        // if the Path was created successfully, create the directory
+        try {
+            if (!directory.exists()) {
+                Files.createDirectories(path);
+                success = true;
+            }
+        } catch (IOException e) {
+            throw new DatasetException("IOException occurred in addDatasetDirectories", e);
+        } catch (UnsupportedOperationException e) {
+            throw new DatasetException("UnsupportedOperationException occurred in addDatasetDirectories", e);
+        } catch (SecurityException e){
+            throw new DatasetException("SecurityException occurred in addDatasetDirectories", e);
+        }
+        return success;
+    }
+
+    /**
+     * Edits the dataset name on the filesystem.
+     *
+     * @param username The username of the owner of the dataset.
+     * @param oldName  The old name of the dataset.
+     * @param newName  The new name of the dataset.
+     * @return Returns true if the edit was successful, false if it failed.
+     */
+
+    private boolean editDatasetDirectories(String username, String oldName, String newName) {
+        boolean returnValue = false;
+        Path path = createPath(username, oldName);
+        File directory = path.toFile();
+        try {
+            if (directory.exists()) {
+                Path newPath = createPath(username, newName);
+                File newDirectory = newPath.toFile();
+                returnValue = directory.renameTo(newDirectory);
+            }
+        } catch (SecurityException e) {
+            throw new DatasetException("SecurityException occurred in editDatasetDirectories", e);
+        } catch (NullPointerException e) {
+            throw new DatasetException("NullPointerException occurred in editDatasetDirectories");
+        }
+        return returnValue;
+    }
+
+    /**
+     * Deletes a dataset on the filesystem.
+     *
+     * @param id The id of the dataset.
+     * @return Returns true if the delete was successful, false if it failed.
+     * @throws SecurityException throws a storage exception if the directory could not be deleted.
+     */
+
+    private boolean deleteDatasetDirectories(Long id) throws SecurityException {
+        boolean success = false;
+        Optional<Dataset> dataset = datasetRepository.findById(id);
+        String username;
+        String name;
+        if (dataset.isPresent()) {
+            username = dataset.get().getUsername();
+            name = dataset.get().getName();
+            Path path = createPath(username, name);
+            File directory = path.toFile();
+            try {
+                success = deleteDirectory(directory);
+            } catch (SecurityException e) {
+                throw new DatasetException("A SecurityException occurred in deleteDatasetDirectories", e);
+            }
+        }
+        return success;
+    }
+
+    /**
+     * Helper method to recursively delete directories.
+     *
+     * @param directoryToBeDeleted The directory / File to be deleted.
+     * @return Returns true if the delete was successful, false if it failed.
+     * @throws SecurityException if directory cannot be deleted.
+     */
+    private boolean deleteDirectory(File directoryToBeDeleted) throws DatasetException {
+        boolean returnValue;
+        File[] allContents;
+        try {
+            allContents = directoryToBeDeleted.listFiles();
+        } catch (SecurityException e) {
+            throw new DatasetException("A SecurityException occurred in deleteDirectory when generating file list", e);
+        }
+        if (allContents != null) {
+            for (File file : allContents) {
+                deleteDirectory(file);
+            }
+        }
+        try {
+            returnValue = directoryToBeDeleted.delete();
+        } catch (SecurityException e) {
+            throw new DatasetException("A SecurityException occurred in deleteDirectory when deleting a directory", e);
+        }
+        return returnValue;
+    }
+
+    /**
+     * A helper method to create a Path given a username and dataset name.
+     *
+     * @param username    The username of the owner of the dataset.
+     * @param datasetName The name of the dataset.
+     * @return Returns a Path.
+     */
+    private Path createPath(String username, String datasetName) {
+        Path path;
+        if (datasetName != null) {
+            try {
+                path = Paths.get(this.rootLocationString, username, datasetName);
+                String pathName = StringUtils.cleanPath(Objects.requireNonNull(path).toString());
+                path = Paths.get(pathName);
+                return path;
+            } catch (InvalidPathException e) {
+                throw new DatasetException("An InvalidPathException occurred in createPath with null datasetName", e);
+            }
+        } else {
+            try {
+                path = Paths.get(this.rootLocationString, username);
+                String pathName = StringUtils.cleanPath(Objects.requireNonNull(path).toString());
+                path = Paths.get(pathName);
+            } catch (InvalidPathException e) {
+                throw new DatasetException("An InvalidPathException occurred in createPath with datasetName present", e);
+            }
+            return path;
+        }
+    }
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/impl/StorageProperties.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/core/service/impl/StorageProperties.java
@@ -1,0 +1,22 @@
+package edu.asu.diging.scriptoocloud.core.service.impl;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:/config.properties")
+public class StorageProperties {
+
+    @Value("${rootUploadLocation}")
+    private String rootLocationString;
+
+    public String getLocation() {
+        return rootLocationString;
+    }
+
+    public void setLocation(String rootLocationString) {
+        this.rootLocationString = rootLocationString;
+    }
+
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/web/DatasetController.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/web/DatasetController.java
@@ -1,0 +1,191 @@
+package edu.asu.diging.scriptoocloud.web;
+
+import edu.asu.diging.scriptoocloud.core.exceptions.DatasetException;
+import edu.asu.diging.scriptoocloud.core.model.IDataset;
+import edu.asu.diging.scriptoocloud.core.service.IDatasetService;
+import edu.asu.diging.scriptoocloud.core.service.impl.DataFileService;
+import edu.asu.diging.scriptoocloud.core.service.impl.DatasetService;
+import edu.asu.diging.scriptoocloud.web.forms.DatasetForm;
+import edu.asu.diging.simpleusers.core.model.IUser;
+import edu.asu.diging.simpleusers.core.service.IUserManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import java.util.List;
+
+
+@Controller
+public class DatasetController {
+
+    private final DatasetService datasetService;
+    private final DataFileService dataFileService;
+    private final IDatasetService datasetManager;
+    private final IUserManager userManager;
+
+    @Autowired
+    public DatasetController(DatasetService datasetService,
+                             DataFileService dataFileService,
+                             IDatasetService datasetManager,
+                             IUserManager userManager) {
+        this.datasetService = datasetService;
+        this.dataFileService = dataFileService;
+        this.datasetManager = datasetManager;
+        this.userManager = userManager;
+    }
+
+    @RequestMapping(value = "datasets/{username}", method = RequestMethod.GET)
+    public String get(Model model, @PathVariable String username) {
+        model.addAttribute("dataset", new DatasetForm());
+        List<IDataset> dbDatasets = datasetService.findAllByUsername(username);
+        if (dbDatasets.size() > 0) {
+            model.addAttribute("dbDatasets", dbDatasets);
+        } else {
+            model.addAttribute("noDatasets", "You Have No Datasets Yet");
+        }
+        return "datasets/index";
+    }
+
+    @RequestMapping(value = "datasets/add", method = RequestMethod.POST)
+    public String post(@Valid @ModelAttribute("dataset") DatasetForm datasetForm,
+                       BindingResult result,
+                       Model model,
+                       RedirectAttributes redirectAttributes) {
+        boolean success;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        IUser user = userManager.findByUsername(username);
+        datasetForm.setUsername(username);
+
+        if (result.hasErrors()) {
+            // Handle form error - They don't show up automatically with redirects
+            if (datasetForm.getName().isEmpty()) {
+                redirectAttributes.addFlashAttribute("noDatasetName", "Dataset Name Cannot Be Empty");
+            }
+            redirectAttributes.addFlashAttribute("dataset", datasetForm);
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+
+        try {
+            success = datasetService.createDataset(datasetForm.getName(), user);
+        } catch (DatasetException e) {
+            model.addAttribute("dataset", new DatasetForm());
+            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+
+        if (success){
+            redirectAttributes.addFlashAttribute("message", "Dataset successfully created");
+        }
+        return "redirect:/datasets/success";
+    }
+
+    @RequestMapping(value = "datasets/delete", method = RequestMethod.POST)
+    public String delete(RedirectAttributes redirectAttributes, HttpServletRequest request) {
+        Long id = Long.parseLong(request.getParameter("delSetId"));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        boolean success;
+        try {
+            success = datasetService.deleteDataset(id);
+        } catch (DatasetException e) {
+            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+        if (success) {
+            redirectAttributes.addFlashAttribute("message", "Dataset successfully deleted");
+        }
+        return "redirect:/datasets/success";
+    }
+
+    @RequestMapping(value = "datasets/edit", method = RequestMethod.POST)
+    public String edit(RedirectAttributes redirectAttributes, HttpServletRequest request) {
+        boolean success;
+        Long id = Long.parseLong(request.getParameter("editSetId"));
+        String newName = request.getParameter("editSetName");
+        IDataset oldDataset = datasetManager.findById(id);
+        String oldName = oldDataset.getName();
+        String username = oldDataset.getUsername();
+        String index = request.getParameter("editIndex");
+
+        if (oldName.equals(newName)) {
+            // Show error at correct index
+            redirectAttributes.addFlashAttribute("errorIndex", index);
+            redirectAttributes.addFlashAttribute("editErrorMessage", "Please Change Dataset Name");
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+        if (newName.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorIndex", index);
+            redirectAttributes.addFlashAttribute("editErrorMessage", "Dataset Name Cannot Be Empty");
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+        try {
+            success = datasetService.editDataset(id, newName, oldName, username);
+        } catch (DatasetException e) {
+            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+        if (success) {
+            redirectAttributes.addFlashAttribute("message", "Dataset successfully edited");
+        }
+        return "redirect:/datasets/success";
+    }
+
+    @RequestMapping(value = "datasets/uploadFile", method = RequestMethod.POST)
+    public String uploadFile(@RequestParam("file") MultipartFile file,
+                             HttpServletRequest request,
+                             RedirectAttributes redirectAttributes,
+                             Model model) {
+        boolean success;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        Long datasetId = Long.parseLong(request.getParameter("fileUploadDatasetId"));
+        String datasetName = request.getParameter("fileUploadDatasetName");
+        if (!file.isEmpty()) {
+            model.addAttribute("file", file);
+        } else {
+            String index = request.getParameter("fileUploadDatasetIndex");
+            redirectAttributes.addFlashAttribute("noFileIndex", index);
+            redirectAttributes.addFlashAttribute("noFileMessage", "Please Choose a File");
+            redirectAttributes.addAttribute("username", username);
+            return "redirect:/datasets/{username}";
+        }
+        success = dataFileService.createFile(file, datasetId, username, datasetName);
+        if (success) {
+            redirectAttributes.addFlashAttribute("message", "File Successfully Uploaded");
+        }
+        return "redirect:/datasets/success";
+    }
+
+    @RequestMapping(value = "datasets/deleteFile", method = RequestMethod.POST)
+    public String deleteFile(HttpServletRequest request,
+                             RedirectAttributes redirectAttributes) {
+        boolean success = false;
+        Long fileId = Long.parseLong(request.getParameter("fileId"));
+        Long datasetId = Long.parseLong(request.getParameter("datasetId"));
+        try {
+            success = datasetService.deleteFileFromDataset(datasetId, fileId);
+        } catch (DatasetException e) {
+            redirectAttributes.addFlashAttribute("message", "Error: File could not be deleted");
+        }
+        if (success) {
+            redirectAttributes.addFlashAttribute("message", "File Successfully Deleted");
+        }
+        return "redirect:/datasets/success";
+    }
+
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/web/DatasetSuccessController.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/web/DatasetSuccessController.java
@@ -1,0 +1,15 @@
+package edu.asu.diging.scriptoocloud.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+public class DatasetSuccessController {
+
+
+    @GetMapping("/datasets/success")
+    public String get(Model model) {
+        return "datasets/success";
+    }
+}

--- a/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/web/forms/DatasetForm.java
+++ b/scriptoocloud/src/main/java/edu/asu/diging/scriptoocloud/web/forms/DatasetForm.java
@@ -1,0 +1,34 @@
+package edu.asu.diging.scriptoocloud.web.forms;
+
+import javax.validation.constraints.NotEmpty;
+
+public class DatasetForm {
+    private Long id;
+    @NotEmpty(message="Please enter a name for this Dataset.")
+    private String name;
+    private String username;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/scriptoocloud/src/main/resources/config.properties
+++ b/scriptoocloud/src/main/resources/config.properties
@@ -3,3 +3,4 @@ db.url=${db.database.url}
 db.username=${db.user}
 db.password=${db.password}
 digingUrl = http://diging.asu.edu/index.html
+rootUploadLocation = uploadDirectory

--- a/scriptoocloud/src/main/webapp/WEB-INF/views/datasets/index.html
+++ b/scriptoocloud/src/main/webapp/WEB-INF/views/datasets/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en"
+      layout:decorate="~{layouts/main}"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="https://www.thymeleaf.org">
+<head>
+    <title>Datasets | ScripToo Cloud</title>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('.delModalBtn').on('click', function () {
+                let id = $(this).data('id');
+                $('input[name="delSetId"]').val(id);
+            })
+        })
+
+    </script>
+</head>
+<body>
+<div layout:fragment="content">
+    <div id="wrapper">
+        <section class="container main-page-content ">
+            <div class="row">
+                <div class="col-md-12">
+                    <h2>Your <strong>Datasets</strong></h2>
+                    <div th:if="${not #strings.isEmpty(noDatasets)}">
+                        <h3 th:text="${noDatasets}"></h3>
+                    </div>
+                    <div>
+                        <form
+                            method="POST"
+                            class="simple_form white-row"
+                            th:action="@{/datasets/add}"
+                            th:object="${dataset}">
+                            <div class="alert alert-danger" th:if="${#fields.hasErrors('*')}">
+                                <p th:each="err : ${#fields.errors('*')}" th:text="${err}"></p>
+                            </div>
+                            <div class="row">
+                                <div class="form-group">
+                                    <div class="col-md-12">
+                                        <label
+                                            for="name">Add a Dataset
+                                        </label>
+                                        <input
+                                            th:field="*{name}"
+                                            class="form-control"
+                                            id="name"
+                                            name="name"
+                                            autofocus="autofocus"
+                                            type="text"
+                                            placeholder="Dataset Name"/>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <input
+                                        class="btn pull-right red-form-button"
+                                        type="submit"
+                                        value="Create"/>
+                                </div>
+                            </div>
+                            <p class="text-danger bg-danger custom-error"
+                               th:if="${not #strings.isEmpty(noDatasetName)}"
+                               th:text="${noDatasetName}">
+                            </p>
+                        </form>
+
+                    </div>
+                    <div th:unless="${#lists.isEmpty(dbDatasets)}">
+                        <div class="row tabular-row" th:each="ds,iterStat : ${dbDatasets}">
+                            <div class="col-md-10">
+                                <form th:action="@{|/datasets/edit|}" method="POST">
+
+                                    <div class="col-md-6">
+                                        <div>
+                                            <div class="inline">
+                                                <span><i class="fas fa-folder fa-2x"></i></span>
+                                            </div>
+                                            <div class="inline">
+                                                <input type="hidden" name="editSetId"
+                                                       th:value="${ds.id}">
+                                                <input type="hidden" name="editIndex"
+                                                       th:value="${iterStat.index}">
+                                                <label>
+                                                    <input name="editSetName" class="fieldInput"
+                                                           th:value="${ds.name}">
+                                                </label>
+                                            </div>
+                                            <p class="text-danger bg-danger custom-error"
+                                               th:if="${not #strings.isEmpty(editErrorMessage)  and
+                                               #strings.equals(iterStat.index, errorIndex)}"
+                                               th:text="${editErrorMessage}">
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6 center">
+                                        <button type="submit" class="btn btn-clear">
+                                            <i class="fas fa-edit"></i> Edit This Dataset
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="col-md-2 center">
+                                <button type="button"
+                                        class="btn btn-clear delModalBtn"
+                                        data-toggle="modal"
+                                        th:attr="data-id=${ds.id}"
+                                        data-target="#deleteDatasetModal">
+                                    <i class="fas fa-trash-alt"></i> Delete This Dataset
+                                </button>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12 file-list"
+                                     th:unless="${#sets.isEmpty(ds.files)}">
+                                    <ul>
+                                        <li th:each="file : ${ds.files}"
+                                            th:inline="text">
+                                        <span class="file-name-span">
+                                            <i class="fas fa-file"></i>
+                                        </span>
+                                            [[${file.name}]]
+                                            <form method="POST"
+                                                  class="inline"
+                                                  th:action="@{/datasets/deleteFile}">
+                                                <input type="hidden" name="fileId"
+                                                       th:value="${file.id}"/>
+                                                <input type="hidden" name="datasetId"
+                                                       th:value="${ds.id}"/>
+                                                <button type="submit" class="btn btn-file">
+                                                    <i class="far fa-times-circle"></i>
+                                                </button>
+                                            </form>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <div class=" row add-file">
+                                <div class="col-md-12">
+                                    <form method="POST"
+                                          class="file-upload-form"
+                                          th:action="@{/datasets/uploadFile}"
+                                          enctype="multipart/form-data">
+                                        <input type="file" name="file"/>
+                                        <input type="hidden" name="fileUploadDatasetId"
+                                               th:value="${ds.id}">
+                                        <input type="hidden" name="fileUploadDatasetIndex"
+                                               th:value="${iterStat.index}">
+                                        <input type="hidden" name="fileUploadDatasetName"
+                                               th:value="${ds.name}">
+                                        <button type="submit" class="btn btn-file"
+                                                th:inline="text">
+                                            [[${#strings.concat('Add Files To: ', ds.name)}]]
+                                            <i class="fas fa-file-medical"></i>
+                                        </button>
+                                        <p class="text-danger bg-danger no-file custom-error"
+                                           th:if="${#strings.equals(iterStat.index, noFileIndex)}"
+                                           th:text="${noFileMessage}">
+                                        </p>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+    <!-- Modal -->
+    <div id="deleteDatasetModal" class="modal fade" tabindex="-1" role="dialog"
+         aria-labelledby="deleteDatasetModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <h1 class="modal-title" id="deleteDatasetModalLabel">WARNING</h1>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to delete this dataset?</p>
+                    <p>This will delete both the DIRECTORY and the FILES it contains.</p>
+                </div>
+                <div class="modal-footer">
+                    <form
+                        method="POST"
+                        th:action="@{/datasets/delete}">
+                        <input type="hidden" name="delSetId">
+                        <button type="button" class="btn gray-form-button" data-dismiss="modal">
+                            Cancel
+                        </button>
+                        <button type="submit" class="btn pull-right red-form-button">Delete</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/scriptoocloud/src/main/webapp/WEB-INF/views/datasets/success.html
+++ b/scriptoocloud/src/main/webapp/WEB-INF/views/datasets/success.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en"
+      layout:decorate="~{layouts/main}"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="https://www.thymeleaf.org">
+<head>
+    <title>Datasets Success | ScripToo Cloud</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div id="wrapper">
+        <section class="container main-page-content ">
+            <div class="row">
+                <div class="col-md-12">
+                    <div th:if="${message}">
+                        <h2 th:text="${message}"></h2>
+                    </div>
+                    <p>
+                        <a class="large-link"
+                           th:href="@{'/datasets/' + ${#authentication.principal.username}}">
+                            Back to Datasets Page
+                        </a>
+                    </p>
+                </div>
+            </div>
+        </section>
+    </div>
+</div>
+</body>
+</html>

--- a/scriptoocloud/src/main/webapp/WEB-INF/views/layouts/main.html
+++ b/scriptoocloud/src/main/webapp/WEB-INF/views/layouts/main.html
@@ -90,6 +90,19 @@
     </div>
 </header>
 
+<div sec:authorize="isAuthenticated()" id="user-navigation">
+    <div class="container">
+        <ul class="breadcrumb">
+            <li class="notactive">
+                <a th:href="@{'/datasets/' + ${#authentication.principal.username} }">My Datasets</a>
+            </li>
+            <li class="active">
+                My Projects
+            </li>
+        </ul>
+    </div>
+</div>
+
 <div th:if="${show_alert}" class="alert alert-${alert_type}" role="alert">${alert_msg}</div>
 
 <!-- Content -->

--- a/scriptoocloud/src/main/webapp/WEB-INF/web.xml
+++ b/scriptoocloud/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.1" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd.xsd">
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
 
     <context-param>
         <param-name>contextClass</param-name>
@@ -10,7 +11,7 @@
         </param-value>
     </context-param>
 
-    <!-- The definition of the Root Spring Container shared by all Servlets 
+    <!-- The definition of the Root Spring Container shared by all Servlets
         and Filters -->
     <context-param>
         <param-name>contextConfigLocation</param-name>
@@ -44,11 +45,26 @@
     </filter-mapping>
 
     <!-- spring security -->
+
+    <!-- Added for file upload -->
+    <filter>
+        <filter-name>MultipartFilter</filter-name>
+        <filter-class>org.springframework.web.multipart.support.MultipartFilter</filter-class>
+    </filter>
+    <!-- End -->
+
     <filter>
         <filter-name>springSecurityFilterChain</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy
         </filter-class>
     </filter>
+
+    <!-- Added for file upload -->
+    <filter-mapping>
+        <filter-name>MultipartFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <!-- End -->
 
     <filter-mapping>
         <filter-name>springSecurityFilterChain</filter-name>
@@ -66,13 +82,21 @@
                 org.springframework.web.context.support.AnnotationConfigWebApplicationContext
             </param-value>
         </init-param>
-        <!-- Again, config locations must consist of one or more comma- or space-delimited 
+        <!-- Again, config locations must consist of one or more comma- or space-delimited
             and fully-qualified @Configuration classes -->
         <init-param>
             <param-name>contextConfigLocation</param-name>
             <param-value>edu.asu.diging.scriptoocloud.config.MvcConfig</param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
+
+        <!-- Added to support file uploads -->
+        <multipart-config>
+            <location>/tmp</location>
+            <max-file-size>26214400</max-file-size>
+            <max-request-size>31457280</max-request-size>
+            <file-size-threshold>0</file-size-threshold>
+        </multipart-config>
     </servlet>
 
     <servlet-mapping>

--- a/scriptoocloud/src/main/webapp/resources/css/custom.css
+++ b/scriptoocloud/src/main/webapp/resources/css/custom.css
@@ -5,15 +5,17 @@ body {
     line-height: 23px;
     margin: 0;
     padding: 0;
+    -webkit-font-smoothing: antialiased;
 }
 
-body, p, table, div, button, input.btn, input {
+body, p, table, div, button, input.btn input {
     font-family: 'Open Sans', Arial, sans-serif !important;
 }
 
 a, a:hover {
     color: #8c1d40;
     text-decoration: none;
+    cursor: pointer;
 }
 
 a.app-title {
@@ -38,7 +40,7 @@ a.sign-in-out:hover {
 .account-button, button.account-button {
     padding: 3px 10px 3px 10px;
     color: #454545;
-    border-radius: 10px;
+    border-radius: 15px;
     border: none;
     line-height: 1.5;
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
@@ -68,13 +70,8 @@ a.sign-in-out:hover {
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99a8b0bc', endColorstr='#59a8b0bc', GradientType=0);
 }
 
-button.account-button {
-    height:22px;
-    padding-top:1px;
-}
-
-.account-button, button.account-button:focus {
-    outline: 0;
+button:focus, button:active, i:focus, .account-button, button.account-button:focus {
+    outline: 0 !important;
 }
 
 .acct-links {
@@ -84,6 +81,14 @@ button.account-button {
 
 .acct-links a {
     font-weight:bold;
+}
+
+a.large-link {
+    font-size:1.25em;
+}
+
+a.large-link:hover {
+    text-decoration: underline;
 }
 
 .header {
@@ -102,6 +107,21 @@ h1 {
     font-size: 2em;
     line-height: 100%;
     font-weight: bold;
+}
+
+.callout {
+    padding: 20px 20px 20px 20px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    background: #fff;
+    margin: 40px;
+    box-shadow: 1px 1px 2px 2px #e6e6e6;
+}
+
+.callout p{
+    font-size: 1.25em;
+    line-height: 1.5em;
+    margin-bottom:0;
 }
 
 b,
@@ -127,10 +147,22 @@ header#topHead {
     padding-top:15px;
 }
 
+div#user-navigation {
+    color: #fff;
+    padding: 20px 0;
+    position: relative;
+    background: #ddd no-repeat 50% 50%;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    -o-background-size: cover;
+    background-size: cover;
+}
+
 /**  Content
  **************************************************************** **/
 .main-page-content {
-    padding-top:70px;
+    padding-top:50px;
+    min-height:400px;
 }
 
 .white-row {
@@ -147,7 +179,7 @@ header#topHead {
  **************************************************************** **/
 footer {
     color: #87919F;
-    font-size: 13px;
+    font-size: 14px;
     overflow: hidden;
 }
 footer a {
@@ -189,7 +221,7 @@ footer .footer-content {
 
 footer .footer-content h3, footer .footer-content h3 a{
     color: #fec627;
-    font-weight: 200;
+    font-weight: 600;
     font-size: 16px;
     margin-bottom: 5px;
 }
@@ -275,7 +307,7 @@ h6 {
 }
 
 /**  Buttons
- **************************************************************** **/
+ ******************************************************************/
 
 .red-form-button {
     color: #FFF;
@@ -297,7 +329,7 @@ h6 {
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c32a5b', endColorstr='#8c1d40',GradientType=0 );
 }
 
-.red-form-button:hover {
+.red-form-button:hover, .red-form-button:active {
     color: #FFF;
     background: #c32a5b;
     /* Old browsers */
@@ -316,27 +348,45 @@ h6 {
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#8c1d40', endColorstr='#c32a5b',GradientType=0 );
 }
 
-.red-form-button:active {
-    box-shadow: 1px 4px 10px 1px rgba(179, 179, 179, 0.86);
-    background: #890602;
+.gray-form-button {
+    color: #3b3b3b;
+    margin-top: 10px;
+    background: #999;
     /* Old browsers */
-    background: -moz-linear-gradient(top, #890602 0%, #d32626 100%);
+    background: -moz-linear-gradient(top, #999 0%, #ccc 100%);
     /* FF3.6+ */
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #890602), color-stop(100%, #d32626));
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #999), color-stop(100%, #ccc));
     /* Chrome,Safari4+ */
-    background: -webkit-linear-gradient(top, #890602 0%, #d32626 100%);
+    background: -webkit-linear-gradient(top, #999 0%, #ccc 100%);
     /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top, #890602 0%, #d32626 100%);
+    background: -o-linear-gradient(top, #999 0%, #ccc 100%);
     /* Opera 11.10+ */
-    background: -ms-linear-gradient(top, #890602 0%, #d32626 100%);
+    background: -ms-linear-gradient(top, #999 0%, #ccc 100%);
     /* IE10+ */
-    background: linear-gradient(to bottom, #890602 0%, #d32626 100%);
+    background: linear-gradient(to bottom, #999 0%, #ccc 100%);
     /* W3C */
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#890602', endColorstr='#d32626',GradientType=0 );
-    /* IE6-9 */
-    transform: translateY(3px);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#999', endColorstr='#ccc',GradientType=0 );
 }
 
+.gray-form-button:hover, .gray-form-button:active {
+    color: #3b3b3b;
+    margin-top: 10px;
+    background: #999;
+    /* Old browsers */
+    background: -moz-linear-gradient(top, #ccc 0%, #999 100%);
+    /* FF3.6+ */
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ccc), color-stop(100%, #999));
+    /* Chrome,Safari4+ */
+    background: -webkit-linear-gradient(top, #ccc 0%, #999 100%);
+    /* Chrome10+,Safari5.1+ */
+    background: -o-linear-gradient(top, #ccc 0%, #999 100%);
+    /* Opera 11.10+ */
+    background: -ms-linear-gradient(top, #ccc 0%, #999 100%);
+    /* IE10+ */
+    background: linear-gradient(to bottom, #ccc 0%, #999 100%);
+    /* W3C */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ccc', endColorstr='#999',GradientType=0 );
+}
 
 /**  Forms
  **************************************************************** **/
@@ -367,6 +417,12 @@ h6 {
     box-shadow: 0 0 10px #9ecaed;
 }
 
+.custom-error {
+    margin-top: 10px;
+    padding: 5px;
+    border-radius: 3px;
+}
+
 .breadcrumb {
     font-size: 15px;
     margin: -3px 0 0;
@@ -378,4 +434,122 @@ h6 {
     -moz-border-radius: 0;
     border-radius: 0;
     border:none;
+}
+
+.breadcrumb li a:hover {
+    color: #333 !important;
+}
+
+input.fieldInput {
+    font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+    border: #B9B9B9 2px solid;
+    padding: 8px;
+    border-radius:6px;
+}
+
+label input.fieldInput {
+    width: 100%;
+}
+
+input.fieldInput:focus {
+    outline: none;
+    border-color: #9ecaed;
+    box-shadow: 0 0 10px #9ecaed;
+}
+
+.table-header-text{
+    font-weight: 900;
+    font-size: 1.25em;
+}
+
+.fieldInputContainer{
+    width: 75%;
+}
+
+.tabular-row{
+    padding: 40px 0 40px 0;
+    margin-top: 10px;
+    margin-bottom: 0;
+    border-top: 1px solid #2E363F;
+}
+
+.center {
+    text-align: center;
+}
+
+/**  Modal
+ ******************************************************************/
+
+.modal-title {
+    text-align: center;
+}
+
+/**  Files
+ ******************************************************************/
+
+.file-list {
+    clear:both;
+}
+
+.file-list ul {
+    list-style: none;
+    margin-left: 25px;
+}
+
+.file-list ul li {
+    font-family: Menlo,Monaco,Consolas,"Courier New",monospace !important;
+    font-weight: bold;
+    background-color: #eaeaea;
+    border: 1px dashed #bfbfbf;
+    padding: 3px;
+}
+
+.inline {
+    display: inline-block;
+}
+
+.add-file {
+    margin: 20px 0 0 50px;
+}
+
+.add-file:hover {
+    text-decoration: underline;
+}
+
+.file-list ul li a i.fa-times-circle {
+    color: #333;
+}
+
+.file-list ul li a i.fa-times-circle:hover {
+    color: #8c1d40;
+}
+
+span.file-name-span {
+    margin-left:10px;
+}
+
+.file-upload-form {
+    width: 250px;
+    padding: 20px;
+    border: 1px solid #333;
+    border-radius: 6px;
+    background: #fff;
+}
+
+.btn-file {
+    color: #8c1d40;
+    background: transparent;
+}
+
+.btn-clear {
+    background: transparent;
+}
+
+.btn-file:hover {
+    color: #2E363F;
+    text-decoration: underline;
+}
+
+.no-file {
+    width: 200px;
 }


### PR DESCRIPTION
I just wanted to get a bit of feedback on this branch from a high-level perspective before I create the test cases in case anything needs to be significantly altered.  The root folder for uploaded Datasets is uploadDirectory in config.properties (this gets put in the server root's bin directory by default) and web.xml has the <multipart-config> attributes (file size, etc.). The values of which can obviously be altered easily.  Currently, users can create, edit, and delete datasets and create, edit, and delete the DataFiles belonging to those Datasets.  All operations are setup to perform CRUD operations on the filesystem and (if successful) the database.